### PR TITLE
Override Strapdown's line-height rule

### DIFF
--- a/_layouts/meta.html
+++ b/_layouts/meta.html
@@ -2,6 +2,11 @@
 <html>
 <head>
 <title>North London Riichi Open</title>
+<style>
+  body {
+    line-height: 1.5 !important;
+  }
+</style>
 </head>
 <body>
 <xmp style="display:none" theme="readable">


### PR DESCRIPTION
Adds a CSS rule to the head of the layout HTML to override the odd rule coming from `strapdown.min.css` that breaks the line height on larger screen sizes. `!important` is needed to override the third-party CSS.